### PR TITLE
Bump Flask-CORS version to mitigate CVE-2020-25032

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,5 +1,5 @@
 # Common requirements used across local dev and production
 Flask==1.1.1
-Flask-Cors==3.0.8
+Flask-Cors==3.0.9
 gevent==1.4.0
 gunicorn==20.0.4


### PR DESCRIPTION
Mitigates https://github.com/kamalgill/cloud-starterkit-flask-appengine/security/dependabot/requirements-common.txt/Flask-Cors/open

NOTE: This PR was opened and merged almost at the same time as https://github.com/kamalgill/cloud-starterkit-flask-appengine/pull/9 was opened by dependabot -- see that PR for more details.